### PR TITLE
Add support for ModUpdater

### DIFF
--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -30,5 +30,13 @@
   },
   "suggests": {
     "flamingo": "*"
+  },
+  
+  "custom": {
+    "modupdater": {
+      "strategy": "curseforge",
+      "projectID": 364540,
+      "strict": false
+    }
   }
 }


### PR DESCRIPTION
[ModUpdater](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater) is a Fabric mod which automatically checks for and downloads updates to other cooperating Fabric mods.

I created this PR from [the developer documentiation](https://gitea.thebrokenrail.com/TheBrokenRail/ModUpdater/src/branch/master/MOD_DEVELOPER.md), but I havenʼt personally tested it; you should double-check that it works before merging.